### PR TITLE
Improvements to HTTP APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ mistune = "^3.0.2"
 h2 = "^4.1.0"
 python-dateutil = { version = "^2.8.2", optional = true }
 tenacity = { version = "^8.2.3", optional = true }
+nest-asyncio = "^1.6.0"  # Needed for GlobalSharedSession only
 
 [tool.poetry.extras]
 uhd-urz = ["python-dateutil", "tenacity"]

--- a/src/elapi/api/__init__.py
+++ b/src/elapi/api/__init__.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401
 from .api import (
-    CustomClient,
+    SimpleClient,
+    GlobalSharedSession,
     APIRequest,
     ElabFTWURLError,
     ElabFTWURL,

--- a/src/elapi/api/__init__.py
+++ b/src/elapi/api/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
 from .api import (
+    SessionDefaults,
     SimpleClient,
     GlobalSharedSession,
     APIRequest,

--- a/src/elapi/api/validators.py
+++ b/src/elapi/api/validators.py
@@ -165,7 +165,7 @@ class PermissionValidator(Validator):
 
         logger = Logger()
         try:
-            session = GETRequest(keep_session_open=True)
+            session = GETRequest()
             caller_data: dict = session(endpoint_name="users", endpoint_id="me").json()
         except (httpx.HTTPError, JSONDecodeError):
             logger.critical(
@@ -214,8 +214,8 @@ class APITokenRWValidator(Validator):
         logger = Logger()
         if self.can_write:
             try:
-                _session = GETRequest()
-                api_token_data: Optional[dict] = _session(
+                session = GETRequest()
+                api_token_data: Optional[dict] = session(
                     endpoint_name="apikeys", endpoint_id="me"
                 ).json()[0]
             except (httpx.HTTPError, JSONDecodeError):

--- a/src/elapi/configuration/__init__.py
+++ b/src/elapi/configuration/__init__.py
@@ -4,6 +4,7 @@ from ._overload_history import (
     ApplyConfigHistory,
     reinitiate_config,
     validate_configuration,
+    preventive_missing_warning,
 )
 
 # noinspection PyUnresolvedReferences

--- a/src/elapi/configuration/overridable_vars.py
+++ b/src/elapi/configuration/overridable_vars.py
@@ -6,7 +6,7 @@ from .config import APIToken
 from ..styles import Missing
 
 
-def _run_validation_once():
+def _run_validation_once() -> None:
     if get_development_mode() is False or get_development_mode() == Missing():
         reinitiate_config()
 

--- a/src/elapi/plugins/bill_teams/cli.py
+++ b/src/elapi/plugins/bill_teams/cli.py
@@ -71,6 +71,7 @@ else:
         ] = False,
     ) -> dict:
         """Get billable teams data."""
+        from ...api import GlobalSharedSession
         from .format import remove_csv_formatter_support
         from ...plugins.commons.cli_helpers import CLIExport, CLIFormat
         from ..commons import Export
@@ -80,38 +81,43 @@ else:
         from .specification import BILLING_INFO_OUTPUT_TEAMS_INFO_FILE_NAME_STUB
 
         remove_csv_formatter_support()
-
-        with stderr_console.status("Validating...\n", refresh_per_second=15):
-            validate = Validate(
-                HostIdentityValidator(), PermissionValidator("sysadmin")
-            )
-            validate()
-        if export is False:
-            _export_dest = None
-
-        if sort_json_format:
-            from .format import JSONSortedFormat  # noqa: F401
-
-        data_format, export_dest, export_file_ext = CLIExport(
-            data_format, _export_dest, export_overwrite
-        )
-        format = CLIFormat(data_format, export_file_ext)
-
-        import asyncio
-        from .bill_teams import (
-            UsersInformation,
-            TeamsInformation,
-            TeamsList,
-        )
-
-        users_info, teams_info = UsersInformation(), TeamsInformation()
         try:
-            tl = TeamsList(asyncio.run(users_info.items()), teams_info.items())
-        except (RuntimeError, InterruptedError) as e:
-            # RuntimeError is raised when users_items() -> event_loop.stop() stops the loop before future is completed.
-            # InterruptedError is raised when JSONDecodeError is triggered.
-            logger.info(f"{APP_NAME} will try again.")
-            raise InterruptedError from e
+            with GlobalSharedSession():
+                with stderr_console.status("Validating...\n", refresh_per_second=15):
+                    validate = Validate(
+                        HostIdentityValidator(), PermissionValidator("sysadmin")
+                    )
+                    validate()
+                if export is False:
+                    _export_dest = None
+
+                if sort_json_format:
+                    from .format import JSONSortedFormat  # noqa: F401
+
+                data_format, export_dest, export_file_ext = CLIExport(
+                    data_format, _export_dest, export_overwrite
+                )
+                format = CLIFormat(data_format, export_file_ext)
+
+                import asyncio
+                from .bill_teams import (
+                    UsersInformation,
+                    TeamsInformation,
+                    TeamsList,
+                )
+
+                users_info, teams_info = UsersInformation(), TeamsInformation()
+                try:
+                    tl = TeamsList(asyncio.run(users_info.items()), teams_info.items())
+                except (RuntimeError, InterruptedError) as e:
+                    # RuntimeError is raised when users_items() -> event_loop.stop() stops the loop before future is completed.
+                    # InterruptedError is raised when JSONDecodeError is triggered.
+                    logger.info(f"{APP_NAME} will try again.")
+                    raise InterruptedError from e
+        except RuntimeError as e:
+            # Mainly to catch KeyboardInterrupt with nest_asyncio. Full error details:
+            # nest_asyncio.py:96: "RuntimeError: Event loop stopped before Future completed."
+            raise Exit(1) from e
         formatted_teams = format(teams := tl.items())
 
         if export:
@@ -185,17 +191,19 @@ else:
             Exit,
             ValidationError,
         )
+        from ...api import GlobalSharedSession
         from ...api.validators import HostIdentityValidator, PermissionValidator
         from .specification import BILLING_INFO_OUTPUT_OWNERS_INFO_FILE_NAME_STUB
 
         remove_csv_formatter_support()
 
         if not skip_essential_validation:
-            with stderr_console.status("Validating...\n", refresh_per_second=15):
-                validate = Validate(
-                    HostIdentityValidator(), PermissionValidator("sysadmin")
-                )
-                validate()
+            with GlobalSharedSession(limited_to="sync"):
+                with stderr_console.status("Validating...\n", refresh_per_second=15):
+                    validate = Validate(
+                        HostIdentityValidator(), PermissionValidator("sysadmin")
+                    )
+                    validate()
         if export is False:
             _export_dest = None
 

--- a/src/elapi/plugins/bill_teams/cli.py
+++ b/src/elapi/plugins/bill_teams/cli.py
@@ -81,45 +81,36 @@ else:
         from .specification import BILLING_INFO_OUTPUT_TEAMS_INFO_FILE_NAME_STUB
 
         remove_csv_formatter_support()
+        with stderr_console.status("Validating...\n", refresh_per_second=15):
+            with GlobalSharedSession(limited_to="sync"):
+                validate = Validate(
+                    HostIdentityValidator(), PermissionValidator("sysadmin")
+                )
+                validate()
+        if export is False:
+            _export_dest = None
+        if sort_json_format:
+            from .format import JSONSortedFormat  # noqa: F401
+        data_format, export_dest, export_file_ext = CLIExport(
+            data_format, _export_dest, export_overwrite
+        )
+        format = CLIFormat(data_format, export_file_ext)
+        import asyncio
+        from .bill_teams import (
+            UsersInformation,
+            TeamsInformation,
+            TeamsList,
+        )
+
+        users_info, teams_info = UsersInformation(), TeamsInformation()
         try:
-            with GlobalSharedSession():
-                with stderr_console.status("Validating...\n", refresh_per_second=15):
-                    validate = Validate(
-                        HostIdentityValidator(), PermissionValidator("sysadmin")
-                    )
-                    validate()
-                if export is False:
-                    _export_dest = None
-
-                if sort_json_format:
-                    from .format import JSONSortedFormat  # noqa: F401
-
-                data_format, export_dest, export_file_ext = CLIExport(
-                    data_format, _export_dest, export_overwrite
-                )
-                format = CLIFormat(data_format, export_file_ext)
-
-                import asyncio
-                from .bill_teams import (
-                    UsersInformation,
-                    TeamsInformation,
-                    TeamsList,
-                )
-
-                users_info, teams_info = UsersInformation(), TeamsInformation()
-                try:
-                    tl = TeamsList(asyncio.run(users_info.items()), teams_info.items())
-                except (RuntimeError, InterruptedError) as e:
-                    # RuntimeError is raised when users_items() -> event_loop.stop() stops the loop before future is completed.
-                    # InterruptedError is raised when JSONDecodeError is triggered.
-                    logger.info(f"{APP_NAME} will try again.")
-                    raise InterruptedError from e
-        except RuntimeError as e:
-            # Mainly to catch KeyboardInterrupt with nest_asyncio. Full error details:
-            # nest_asyncio.py:96: "RuntimeError: Event loop stopped before Future completed."
-            raise Exit(1) from e
+            tl = TeamsList(asyncio.run(users_info.items()), teams_info.items())
+        except (RuntimeError, InterruptedError) as e:
+            # RuntimeError is raised when users_items() -> event_loop.stop() stops the loop before future is completed.
+            # InterruptedError is raised when JSONDecodeError is triggered.
+            logger.info(f"{APP_NAME} will try again.")
+            raise InterruptedError from e
         formatted_teams = format(teams := tl.items())
-
         if export:
             export_teams = Export(
                 export_dest,

--- a/src/elapi/plugins/commons/export.py
+++ b/src/elapi/plugins/commons/export.py
@@ -96,12 +96,11 @@ class ExportPathValidator(PathValidator):
         self._can_overwrite = value
 
     def validate(self) -> ProperPath:
-        from ...configuration import APP_NAME, KEY_EXPORT_DIR, get_active_export_dir
+        from ...configuration import APP_NAME, KEY_EXPORT_DIR, get_active_export_dir, preventive_missing_warning
         from ...styles import stdin_console, NoteText
-        from ...utils import missing_warning
 
         export_dir = get_active_export_dir()
-        missing_warning((KEY_EXPORT_DIR, export_dir))
+        preventive_missing_warning((KEY_EXPORT_DIR, export_dir))
         if self.export_path is not None:
             try:
                 path = ProperPath(super().validate(), err_logger=logger)

--- a/src/elapi/plugins/commons/get_information.py
+++ b/src/elapi/plugins/commons/get_information.py
@@ -5,6 +5,7 @@ from typing import Awaitable
 import httpx
 from httpx import Response
 
+from ...api import GlobalSharedSession
 from ...core_validators import Exit
 from ...loggers import Logger
 
@@ -65,8 +66,10 @@ class RecursiveInformation:
         # https://docs.python.org/3/library/asyncio-dev.html#detect-never-retrieved-exceptions
         for task in asyncio.all_tasks(event_loop):
             task.cancel()
-        if event_loop.is_running():
-            event_loop.stop()  # Will raise RuntimeError
+        if GlobalSharedSession._instance is None:
+            if event_loop.is_running():
+                event_loop.stop()  # Will raise RuntimeError
+                # (most likely because some tasks are still remaining)
 
     async def items(self):
         from ...api.endpoint import FixedAsyncEndpoint, RecursiveGETEndpoint

--- a/src/elapi/plugins/experiments/cli.py
+++ b/src/elapi/plugins/experiments/cli.py
@@ -63,6 +63,7 @@ def get(
     """
     import sys
     from ...core_validators import Validate
+    from ...api import GlobalSharedSession
     from ...api.validators import HostIdentityValidator
     from ..commons import Export
     from ...styles import Highlight
@@ -71,62 +72,63 @@ def get(
     )  # must be imported for all formats to be registered by BaseFormat
     from ...core_validators import Exit
 
-    validate_config = Validate(HostIdentityValidator())
-    validate_config()
+    with GlobalSharedSession(limited_to="sync"):
+        validate_config = Validate(HostIdentityValidator())
+        validate_config()
 
-    if export is False:
-        _export_dest = None
-    try:
-        experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
-    except ValidationError as e:
-        logger.error(e)
-        raise typer.Exit(1)
-    else:
-        data_format, export_dest, export_file_ext = CLIExport(
-            data_format, _export_dest, export_overwrite
-        )
-        format = CLIFormat(data_format, export_file_ext)
+        if export is False:
+            _export_dest = None
+        try:
+            experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
+        except ValidationError as e:
+            logger.error(e)
+            raise typer.Exit(1)
+        else:
+            data_format, export_dest, export_file_ext = CLIExport(
+                data_format, _export_dest, export_overwrite
+            )
+            format = CLIFormat(data_format, export_file_ext)
 
-        if isinstance(format, formats.BinaryFormat):
-            if not export:
-                logger.info(
-                    f"Data with format '{data_format}' cannot be shown on the terminal. "
-                    f"Data will be exported."
+            if isinstance(format, formats.BinaryFormat):
+                if not export:
+                    logger.info(
+                        f"Data with format '{data_format}' cannot be shown on the terminal. "
+                        f"Data will be exported."
+                    )
+                export = True
+                response = FixedExperimentEndpoint().get(
+                    experiment_id, query={"format": data_format.lower()}
                 )
-            export = True
-            response = FixedExperimentEndpoint().get(
-                experiment_id, query={"format": data_format.lower()}
-            )
-            formatted_data = format(response_data := response.content)
-        else:
-            response = FixedExperimentEndpoint().get(experiment_id)
-            formatted_data = format(response_data := response.json())
-
-        if export:
-            file_name_stub = (
-                f"experiment_{experiment_id}" if experiment_id else "experiment"
-            )
-            export = Export(
-                export_dest,
-                file_name_stub=file_name_stub,
-                file_extension=format.convention,
-                format_name=format.name,
-            )
-            export(data=formatted_data, verbose=True)
-        else:
-            if highlight_syntax is True:
-                highlight = Highlight(format.name)
-                if not response.is_success:
-                    stderr_console.print(highlight(formatted_data))
-                    raise Exit(1)
-                stdin_console.print(highlight(formatted_data))
+                formatted_data = format(response_data := response.content)
             else:
-                if not response.is_success:
-                    typer.echo(formatted_data, file=sys.stderr)
-                    raise Exit(1)
-                typer.echo(formatted_data)
-        response.close()
-        return response_data
+                response = FixedExperimentEndpoint().get(experiment_id)
+                formatted_data = format(response_data := response.json())
+
+            if export:
+                file_name_stub = (
+                    f"experiment_{experiment_id}" if experiment_id else "experiment"
+                )
+                export = Export(
+                    export_dest,
+                    file_name_stub=file_name_stub,
+                    file_extension=format.convention,
+                    format_name=format.name,
+                )
+                export(data=formatted_data, verbose=True)
+            else:
+                if highlight_syntax is True:
+                    highlight = Highlight(format.name)
+                    if not response.is_success:
+                        stderr_console.print(highlight(formatted_data))
+                        raise Exit(1)
+                    stdin_console.print(highlight(formatted_data))
+                else:
+                    if not response.is_success:
+                        typer.echo(formatted_data, file=sys.stderr)
+                        raise Exit(1)
+                    typer.echo(formatted_data)
+            response.close()
+            return response_data
 
 
 @app.command(short_help="Add new content to an existing experiment.")
@@ -160,44 +162,48 @@ def append(
     Add new content to an existing experiment.
     """
     from ...core_validators import Validate
+    from ...api import GlobalSharedSession
     from ...api.validators import HostIdentityValidator
     from ...path import ProperPath
 
-    validate_config = Validate(HostIdentityValidator())
-    validate_config()
-    try:
-        experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
-    except ValidationError as e:
-        logger.error(e)
-        raise typer.Exit(1)
-    else:
-        if content_text and content_path:
-            logger.error("Either '--text/-t' or '--path/-P' can be defined, not both!")
+    with GlobalSharedSession(limited_to="sync"):
+        validate_config = Validate(HostIdentityValidator())
+        validate_config()
+        try:
+            experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
+        except ValidationError as e:
+            logger.error(e)
             raise typer.Exit(1)
-        if content_text is not None:
-            content: str = content_text
-        elif content_path is not None:
-            if not (content_path := ProperPath(content_path)).kind == "file":
-                logger.error(f" Given path '{content_path}' must be a file!")
-                raise typer.Exit(1)
-            with content_path.open() as f:
-                try:
-                    content: str = f.read()
-                except UnicodeDecodeError:
-                    logger.error("File in given path must be UTF-8 encoded!")
-                    raise typer.Exit(1)
         else:
-            content: str = ""
-        if not content:
+            if content_text and content_path:
+                logger.error(
+                    "Either '--text/-t' or '--path/-P' can be defined, not both!"
+                )
+                raise typer.Exit(1)
+            if content_text is not None:
+                content: str = content_text
+            elif content_path is not None:
+                if not (content_path := ProperPath(content_path)).kind == "file":
+                    logger.error(f" Given path '{content_path}' must be a file!")
+                    raise typer.Exit(1)
+                with content_path.open() as f:
+                    try:
+                        content: str = f.read()
+                    except UnicodeDecodeError:
+                        logger.error("File in given path must be UTF-8 encoded!")
+                        raise typer.Exit(1)
+            else:
+                content: str = ""
+            if not content:
+                stdin_console.print(
+                    "[yellow]Content is empty. Nothing was appended to experiment.[/yellow]"
+                )
+                raise typer.Exit()
+            append_to_experiment(experiment_id, content, markdown_to_html)
             stdin_console.print(
-                "[yellow]Content is empty. Nothing was appended to experiment.[/yellow]"
+                "[green]Successfully appended content to experiment.[/green]"
             )
-            raise typer.Exit()
-        append_to_experiment(experiment_id, content, markdown_to_html)
-        stdin_console.print(
-            "[green]Successfully appended content to experiment.[/green]"
-        )
-        return content
+            return content
 
 
 @app.command(short_help="Attach a file to an experiment.")
@@ -232,23 +238,25 @@ def upload_attachment(
     """
     from ...core_validators import Validate
     from ...api.validators import HostIdentityValidator
+    from ...api import GlobalSharedSession
     from .experiments import attach_to_experiment
 
-    validate_config = Validate(HostIdentityValidator())
-    validate_config()
-    try:
-        experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
-    except ValidationError as e:
-        logger.error(e)
-        raise typer.Exit(1)
-    else:
-        attach_to_experiment(
-            experiment_id,
-            file_path=path,
-            attachment_name=attachment_name,
-            comment=comment,
-        )
-        stdin_console.print("[green]Successfully attached to experiment.[/green]")
+    with GlobalSharedSession(limited_to="sync"):
+        validate_config = Validate(HostIdentityValidator())
+        validate_config()
+        try:
+            experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
+        except ValidationError as e:
+            logger.error(e)
+            raise typer.Exit(1)
+        else:
+            attach_to_experiment(
+                experiment_id,
+                file_path=path,
+                attachment_name=attachment_name,
+                comment=comment,
+            )
+            stdin_console.print("[green]Successfully attached to experiment.[/green]")
 
 
 @app.command(short_help="Download an attachment from an experiment.")
@@ -289,48 +297,54 @@ def download_attachment(
     """
     from ...core_validators import Validate
     from ...api.validators import HostIdentityValidator
+    from ...api import GlobalSharedSession
     from ...plugins.commons import Export
     from .experiments import download_attachment
 
-    validate_config = Validate(HostIdentityValidator())
-    validate_config()
+    with GlobalSharedSession(limited_to="sync"):
+        validate_config = Validate(HostIdentityValidator())
+        validate_config()
 
-    if export is False:
-        _export_dest = None
-    export = True  # export is always true for downloading attachment
-    try:
-        experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
-    except ValidationError as e:
-        logger.error(e)
-        raise typer.Exit(1)
-    else:
+        if export is False:
+            _export_dest = None
+        export = True  # export is always true for downloading attachment
         try:
-            (
-                attachment,
-                attachment_real_id,
-                attachment_name,
-                attachment_extension,
-                attachment_hash,
-                attachment_creation_date,
-            ) = download_attachment(experiment_id, attachment_id)
-        except ValueError as e:
+            experiment_id = Validate(ExperimentIDValidator(experiment_id)).get()
+        except ValidationError as e:
             logger.error(e)
             raise typer.Exit(1)
         else:
-            data_format, export_dest, export_file_ext = CLIExport(
-                attachment_extension, _export_dest, export_overwrite
-            )
-            _is_real_id = attachment_id == attachment_real_id
-            if export:
-                if export_file_ext and export_file_ext != attachment_extension:
-                    logger.info(
-                        f"File extension is '{export_file_ext}' but data format will be '{attachment_extension}'."
-                    )
-                file_name_stub = f"attachment_{attachment_real_id if _is_real_id else attachment_hash[:6]}_{attachment_name}"
-                export = Export(
-                    export_dest,
-                    file_name_stub=file_name_stub,
-                    file_extension=attachment_extension,
-                    format_name=data_format,
+            try:
+                (
+                    attachment,
+                    attachment_real_id,
+                    attachment_name,
+                    attachment_extension,
+                    attachment_hash,
+                    attachment_creation_date,
+                ) = download_attachment(experiment_id, attachment_id)
+            except ValueError as e:
+                logger.error(e)
+                raise typer.Exit(1)
+            else:
+                data_format, export_dest, export_file_ext = CLIExport(
+                    attachment_extension, _export_dest, export_overwrite
                 )
-                export(data=attachment, verbose=True)
+                _is_real_id = attachment_id == attachment_real_id
+                if export:
+                    if export_file_ext and export_file_ext != attachment_extension:
+                        logger.info(
+                            f"File extension is '{export_file_ext}' but "
+                            f"data format will be '{attachment_extension}'."
+                        )
+                    file_name_stub = (
+                        f"attachment_{attachment_real_id if _is_real_id else attachment_hash[:6]}_"
+                        f"{attachment_name}"
+                    )
+                    export = Export(
+                        export_dest,
+                        file_name_stub=file_name_stub,
+                        file_extension=attachment_extension,
+                        format_name=data_format,
+                    )
+                    export(data=attachment, verbose=True)

--- a/src/elapi/utils/__init__.py
+++ b/src/elapi/utils/__init__.py
@@ -1,2 +1,8 @@
 from .messages import TupleList, MessagesList, add_message  # noqa: F401
-from .utils import check_reserved_keyword, missing_warning, NoException  # noqa: F401
+from .utils import (  # noqa: F401
+    check_reserved_keyword,  # noqa: F401
+    get_sub_package_name,  # noqa: F401
+    update_kwargs_with_defaults,  # noqa: F401
+    PreventiveWarning,  # noqa: F401
+    NoException,  # noqa: F401
+)

--- a/src/elapi/utils/utils.py
+++ b/src/elapi/utils/utils.py
@@ -1,8 +1,9 @@
 import re
-from typing import Any, Iterable, Tuple
+
+from ..styles import Missing
 
 
-class PreventiveWarning(Exception): ...
+class PreventiveWarning(RuntimeWarning): ...
 
 
 def check_reserved_keyword(
@@ -23,36 +24,23 @@ def check_reserved_keyword(
         ) from error_instance
 
 
-def missing_warning(fields: Tuple[str, Any], /) -> None:
-    from .. import configuration
-    from .._names import KEY_DEVELOPMENT_MODE
-    from ..styles import Missing
-
-    if not isinstance(fields, Iterable) and not isinstance(fields, str):
+def get_sub_package_name(dunder_package: str, /) -> str:
+    if not isinstance(dunder_package, str):
         raise TypeError(
-            f"{missing_warning.__name__} only accepts an iterable of key-value pair."
+            f"{get_sub_package_name.__name__} only accepts __package__ as string."
         )
-    try:
-        key, value = fields
-    except ValueError as e:
-        raise ValueError(
-            "Only a pair of configuration key and its value in an "
-            f"iterable can be passed to {missing_warning.__name__}."
-        ) from e
-    if isinstance(value, Missing):
-        key = key.lower()
-        raise PreventiveWarning(
-            f"Value for '{key}' from configuration file is missing. "
-            f"This is not necessarily a critical error but a future operation might fail. "
-            f"If '{key}' is supposed to fallback to a default value or if you want to "
-            f"get a more precise error message, make sure to run function "
-            f"'{configuration.reinitiate_config.__name__}()' (can be imported with "
-            f"'from {configuration.__name__} import {configuration.reinitiate_config.__name__}') "
-            f"before running anything else. You could also just define a valid value for '{key}' "
-            f"in configuration file. This warning may also be shown because '{KEY_DEVELOPMENT_MODE.lower()}' "
-            f"is set to '{True}' in configuration file. In most cases, just running "
-            f"'{configuration.reinitiate_config.__name__}()' should fix this issue."
-        )
+    match = re.match(r"(^[a-z_]([a-z0-9_]+)?)\.", dunder_package[::-1], re.IGNORECASE)
+    # Pattern almost follows: https://packaging.python.org/en/latest/specifications/name-normalization/
+    if match is not None:
+        return match.group(1)[::-1]
+    raise ValueError("No matching sub-package name found.")
+
+
+def update_kwargs_with_defaults(kwargs: dict, /, defaults: dict) -> None:
+    key_arg_missing = Missing("Keyword argument missing")
+    for default_key, default_val in defaults.items():
+        if kwargs.get(default_key, key_arg_missing) is key_arg_missing:
+            kwargs.update({default_key: default_val})
 
 
 class NoException(Exception): ...


### PR DESCRIPTION
This PR mainly brings improvements that shaves off 1-2 seconds (!) of heavy-duty plugins like `bill-teams` and `experiments`. 

## Shared clients

elAPI provides the following _core_ APIs that can be imported from `elapi.api` that do the heavy lifting of all HTTP calls to eLabFTW without having to worry about configuring HTTP client and make working with eLab API responses convenient.

- `GETRequest`
- `POSTRequest`
- `PATCHRequest`
- `DELETERequest`
- `AsyncGETRequest`
- `AsyncPOSTRequest`
- `AsyncPATCHRequest`
- `AsyncDELETERequest`

Each one of them by default opens a connection once, and closes it **immediately after one** HTTP request. This is useful when we only need a single request (e.g., `elapi get <endpoint name>` command) and don't want to worry about forgetting to close the request.
```py
from elapi.api import GETRequest

session = GETRequest()  # Connection not open yet
print(session(endpoint_name="info").json())  # Connection is open and closed as soon as response is received
```

This immediate closing of connection can soon become very limiting as we need to make repeated requests. A `keep_session_open` keyword argument was introduced before.
```py
from elapi.api import GETRequest, POSTRequest, PATCHRequest, DELETERequest

s1 = GETRequest(keep_session_open=True)  # Default is False
s2 = POSTRequest(keep_session_open=True) 
s3 = PATCHRequest(keep_session_open=True)
s4 = DELETERequest(keep_session_open=True)

print(s1(endpoint_name="info").json())  # A new connection opens
print(s2(endpoint_name="users", data={"firstname": "John", "lastname": "Doe", "email": "john_doe@itnerd.de", "team": 0}))
# Another new connection opens
# If we also call s3, and s4 as well, two more new connections will open

# All open connections manually need to be closed
s1.close()
s2.close()
s3.close()
s4.close()
```

Not only `keep_session_open` would open individual connections for each `GET`, `POST`, `PATCH` and `DELETE`, we would also need to make sure to close them manually. We **deprecate** `keep_session_open` in this PR, and introduce `SimpleClient` and the replacement of `keep_session_open`,  `shared_client`.

```py
from elapi.api import SimpleClient, GETRequest, POSTRequest

client = SimpleClient(is_async_client=False)  # Has already been configured with host URL and API key information from elapi.yml
# Connection opens at "SimpleClient()" immediately
s1 = GETRequest(shared_client=client)  # Default shared_client is None; sharing the same client
s2 = POSTRequest(shared_client=client)  # Sharing the same client

print(s1(endpoint_name="info").json())  # Connection alredy opened in "client" definition
print(s2(endpoint_name="users", data={"firstname": "John", "lastname": "Doe", "email": "john_doe@itnerd.de", "team": 0}))

# Close all open connections
client.close()
```
 
This eases sharing the same client when needed. `SimpleClient` also just returns a [`httpx.Client`](https://www.python-httpx.org/api/#client) or [`httpx.AsyncClient`](https://www.python-httpx.org/api/#asyncclient) depending on the value of keyword argument `is_async_client`. So it can also be used in ways `httpx.Client`/`httpx.AsyncClient` can be used. I.e., `SimpleClient` can also be used as context manager.

```py
from elapi.api import SimpleClient, GETRequest, POSTRequest

with SimpleClient(is_async_client=False)  as client:
    # Has already been configured with host URL and API key information from elapi.yml
    # Connection opens at "SimpleClient()" immediately
    s1 = GETRequest(shared_client=client)  # Sharing the same client
    s2 = POSTRequest(shared_client=client)  # Sharing the same client

    print(s1(endpoint_name="info").json())  # Connection alredy opened in "client" definition
    print(s2(endpoint_name="users", data={"firstname": "John", "lastname": "Doe", "email": "john_doe@itnerd.de", "team": 0}))
```

With context manager, we need not to worry about closing the connections, as they are closed when context manager is automatically.

This solution still inherits one big problem. All existing code that does not use `shared_client` argument will now need to be updated. In the next section, we will introduce a solution to that.

## `GlobalSharedSession`

In the following example, we pseudo-code a script that uses a number of aforementioned elAPI HTTP APIs and runs some advanced automation task.

```py

def check_user_permission():
    # Do something with GETRequest
    ...

def get_users_data():
    check_user_permission()  # Run permission validation
    # Do something with GETRequest
    ...

def modify_experiments_data():
    # Do something with POSTRequest, PATCHRequest
    ...

def delete_resources():
    # Do something with DELETERequest
    ...

def main():
    # Main function runs all the functions above
    check_user_permission()
    get_users_data()
    modify_experiments_data()
    delete_resources()
    # cleanup
```

Since each function makes calls to one or more of `GET`, `POST`, `PATCH` and `DELETE`, this script would be perfect use-case of `shared_client`. But that would require updating the code of all 5 functions. In this PR, we introduce `GlobalSharedSession` that lets us avoid just that using the power of OOP (although the user doesn't need to deal with any OOP). The `main` function can use a single connection to make all requests in the following way:

```py
from elapi.api import GlobalSharedSession

def check_user_permission():
    # Do something with GETRequest
    ...

def get_users_data():
    check_user_permission()  # Run permission validation
    # Do something with AsyncGETRequest
    ...

def modify_experiments_data():
    # Do something with POSTRequest, PATCHRequest
    ...

def delete_resources():
    # Do something with DELETERequest
    ...

def main():
    with GlobalSharedSession():  # <- This line only
        # Main function runs all the functions above
        check_user_permission()
        get_users_data()
        modify_experiments_data()
        delete_resources()
    # cleanup
```

The change in one line will now force all elAPI HTTP APIs to use a single connection (internally, of course, its using HTTPX connection pooling) and automatically closes it accordingly. **`GlobalSharedSession` has been added to all elAPI CLI commands.**

### `GlobalSharedSession` benchmark

We already mentioned in the introduction that `GlobalSharedSession` trims a mere 1-2 seconds. That is the case when we're making a single or a few eLab API calls. We use `hyperfine` to run a simple benchmark of `elapi get users` targeting server `dev-002` (with more than 2500+ users). Here, `~/.local/bin/elapi` **is not** using `GlobalSharedSession`, and `elapi` command is.

```sh
$ hyperfine --warmup 3 --runs 15 "~/.local/bin/elapi get users" "elapi get users"
Benchmark 1: ~/.local/bin/elapi get users
  Time (mean ± σ):     838.4 ms ± 333.6 ms    [User: 277.0 ms, System: 77.5 ms]
  Range (min … max):   689.1 ms … 1988.4 ms    15 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: elapi get users
  Time (mean ± σ):     715.7 ms ±  13.3 ms    [User: 274.6 ms, System: 77.5 ms]
  Range (min … max):   693.7 ms … 746.4 ms    15 runs

Summary
  elapi get users ran
    1.17 ± 0.47 times faster than ~/.local/bin/elapi get users
```

This is not a significant improvement and the final number (1.17x) fluctuates a lot.

Where `GlobalSharedSession` truly makes a big difference is when we run HTTP APIs without `shared_client`, i.e., when we do not update existing code. Let's benchmark an example that reflects that. The following benchmark compares the speed of 10-times repeating `GET` (not async) requests to endpoint `info` in a loop between with-`GlobalSharedSession` and without.
<table>
  <tr>
    <td><code>~/.local/bin/elapi awesome repeated-get-requests info</code></td>
    <td><code>elapi awesome repeated-get-requests info</code></td>
  </tr>
  <tr>
    <td><code>with GlobalSharedSession():
    for _ in range(10):
		validate = Validate(HostIdentityValidator(), PermissionValidator(group="sysadmin"))
		validate()
		r = GETRequest()
		print(f'Request {_}: {r(endpoint_name)}')</code></td>
    <td><code>for _ in range(10):
    validate = Validate(HostIdentityValidator(), PermissionValidator(group="sysadmin"))
    validate()
    r = GETRequest()
    print(f'Request {_}: {r(endpoint_name)}')</code></td>
  </tr>
</table>

Running `hyperfine`:

```sh
$ hyperfine --warmup 3 --runs 10 "~/.local/bin/elapi awesome repeated-get-requests info" "elapi awesome repeated-get-requests info"
Benchmark 1: ~/.local/bin/elapi awesome repeated-get-requests info
  Time (mean ± σ):      6.320 s ±  2.856 s    [User: 0.737 s, System: 0.121 s]
  Range (min … max):    4.729 s … 13.939 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: elapi awesome repeated-get-requests info
  Time (mean ± σ):      3.161 s ±  0.154 s    [User: 0.349 s, System: 0.090 s]
  Range (min … max):    3.082 s …  3.586 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  elapi awesome repeated-get-requests info ran
    2.00 ± 0.91 times faster than ~/.local/bin/elapi awesome repeated-get-requests info
```

The for loop making `GETRequest()` calls and some more calls for permission validation, is **almost 2x faster** with `GlobalSharedSession`.

### `GlobalSharedSession` gotchas

1. `GlobalSharedSession` will override any and all arguments passed to elAPI HTTP APIs. This can be undesirable if the user is doing something specific with one of the API classes. `GlobalSharedSession` will show warning log for when it is necessarily overriding such arguments.
2. By default `GlobalSharedSession` will open two connections only one for sync connection and another for async connection. If we only want to work with sync connections, we should use `GlobalSharedSession(limited_to="sync")`, and `GlobalSharedSession` will not open or override any of the async HTTP APIs. `limited_to` can accept `sync` or `async` or `all` (default is `all`).
3. We needed to add one more external dependency [`nest-asyncio`](https://pypi.org/project/nest-asyncio/) for `GlobalSharedSession` to properly work.
4. `GlobalSharedSession` can be used as a normal class as well instead of using it as a context manager. In which case, the session must be closed manually. Though, using it as a context manager is more recommended.

```py
session = GlobalSharedSession()
# <Make some API calls>
session.close()
```
5. `GlobalSharedSession` can be used multiple times. Each time a new connection will be opened after closing the previous connection (if GSS is used as a context manager). Though, this is **intended** and not a gotcha.
```py
with GlobalSharedSession():
    # <Make some API calls>

with GlobalSharedSession(limited_to="sync"):
    # <Make some more API calls>
```