### PR TITLE
Merge dev into main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: AnyIO",
-    "Framework   :: AsyncIO",
+    "Framework :: AsyncIO",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Natural Language :: English",


### PR DESCRIPTION
Fix bad spaces in classifiers

The extra spaces caused PyPI upload to fail with the following error from uv: error: Failed to publish `dist/elapi-2.4.0-py3-none-any.whl` to https://upload.pypi.org/legacy/
  Caused by: Upload failed with status code 400 Bad Request. Server says: 400 'Framework   :: AsyncIO' is not a valid classifier. See https://packaging.python.org/specifications/core-metadata for more information.